### PR TITLE
Clean up linkcheck excludes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -324,19 +324,7 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = [
-    "http://www.definiens.com",
-    "https://www.imagic.ch/",
-    "https://github.com/ome/",
-    "https://strandls.com", # SSL certificate verify failed
     # See https://www.ncbi.nlm.nih.gov/pmc/about/copyright/
     # The PMC web site restricts access by the default Sphinx agent
-    "https://www.ncbi.nlm.nih.gov/pmc/.*",
-    "https://eliceirilab.org/.*", # ConnectTimeoutError
-    "https://www.fei.com/.*", # SSL certificate expired
-    "http://www.perkinelmer.com/", # 500 Error
-    "http://mayachitra.com/", # SSL certificate expired
-    "https://www.cytivalifesciences.com/",
-    "https://www.mediacy.com/", # https://www.digicert.com/ does not trust the issuer, but link is valid
-    "http://www.bitplane.com", # SSL certificate expired
-    "https://imaris.oxinst.com/.*", # SSL certificate expired
+    "https://www.ncbi.nlm.nih.gov/pmc/.*"
 ]

--- a/conf.py
+++ b/conf.py
@@ -326,5 +326,7 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
 linkcheck_ignore = [
     # See https://www.ncbi.nlm.nih.gov/pmc/about/copyright/
     # The PMC web site restricts access by the default Sphinx agent
-    "https://www.ncbi.nlm.nih.gov/pmc/.*"
+    "https://www.ncbi.nlm.nih.gov/pmc/.*",
+    "https://www.cytivalifesciences.com/",
+    "http://www.cellimagelibrary.org/"
 ]

--- a/ome-tiff/code.rst
+++ b/ome-tiff/code.rst
@@ -65,7 +65,7 @@ with:
 
 .. seealso::
 
-    `BigTIFF file format specification <https://www.awaresystems.be/imaging/tiff/bigtiff.html>`__
+    `BigTIFF file format specification <https://web.archive.org/web/20240706160214/https://www.awaresystems.be/imaging/tiff/bigtiff.html>`__
 
 Modifying a TIFF comment
 ------------------------

--- a/ome-tiff/data.rst
+++ b/ome-tiff/data.rst
@@ -27,7 +27,7 @@ and imaging this sample data.
 
 The datasets were acquired on a multiphoton workstation (2.1 GHz Athlon
 XP 3200+ with 1GB of RAM) using
-`WiscScan <https://eliceirilab.org/software/wiscscan/>`_. All image
+`WiscScan <https://loci.wisc.edu/wiscscan/>`_. All image
 planes were collected at 512 × 512 resolution in 8-bit grayscale, with an
 integration value of 2.
 

--- a/ome-tiff/index.rst
+++ b/ome-tiff/index.rst
@@ -43,7 +43,6 @@ OME-TIFF is supported by:
 * `Bitplane AG <http://www.bitplane.com/>`_
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Cytiva <https://www.cytivalifesciences.com/>`_ (formerly GE Healthcare, Applied Precision)
-* `Definiens <http://www.definiens.com>`_
 * `DRVision Technologies LLC <https://www.drvtechnologies.com>`_
 * `Image-Pro by Media Cybernetics, Inc. <https://www.mediacy.com/>`_
 * `iMagic <https://www.imagic.ch/en>`_

--- a/ome-tiff/index.rst
+++ b/ome-tiff/index.rst
@@ -41,7 +41,7 @@ OME-TIFF is supported by:
 
 * `BIOVIA <https://www.3ds.com/products-services/biovia/>`_
 * `Bitplane AG <http://www.bitplane.com/>`_
-* `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
+* `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/en/home.html>`_
 * `Cytiva <https://www.cytivalifesciences.com/>`_ (formerly GE Healthcare, Applied Precision)
 * `DRVision Technologies LLC <https://www.drvtechnologies.com>`_
 * `Image-Pro by Media Cybernetics, Inc. <https://www.mediacy.com/>`_

--- a/ome-tiff/specification.rst
+++ b/ome-tiff/specification.rst
@@ -14,7 +14,7 @@ An OME-TIFF dataset consists of:
 
 - one or more files in standard TIFF_ format with the file extension
   ``.ome.tif`` or ``.ome.tiff`` or
-  `BigTIFF format <https://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
+  `BigTIFF format <https://web.archive.org/web/20240706160214/https://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
   with one of these same file extensions or a BigTIFF-specific
   extension ``.ome.tf2``, ``.ome.tf8`` or ``.ome.btf``
 - a string of OME-XML metadata embedded in the ImageDescription tag of the
@@ -50,7 +50,7 @@ specification) shows the organization of a TIFF header along with the
 placement of the OME-XML metadata block.  Note this is for the TIFF
 standard specification only; the header structure is slightly
 different for BigTIFF; see the `BigTIFF file format specification
-<https://www.awaresystems.be/imaging/tiff/bigtiff.html>`__. A TIFF file can
+<https://web.archive.org/web/20240706160214/https://www.awaresystems.be/imaging/tiff/bigtiff.html>`__. A TIFF file can
 contain any number of IFDs, with each one specifying an image plane along with
 certain accompanying metadata such as pixel dimensions, physical
 dimensions, bit depth, color table, etc. One of the fields an IFD can

--- a/ome-tiff/tools.rst
+++ b/ome-tiff/tools.rst
@@ -28,7 +28,7 @@ If you are looking for a solution in Java, there are several options.
 Bio-Formats can read OME-TIFF files, as well as convert from many
 third-party formats into OME-TIFF format—see the :doc:`example source code
 page <code>` for specific examples. Alternatively, the open
-source `ImageJ <https://imagej.nih.gov/ij/>`_ application reads
+source `ImageJ <https://imagej.net/ij/>`_ application reads
 multi-page TIFF files, storing the TIFF comment into the associated
 FileInfo object's "description" field.
 


### PR DESCRIPTION
Fixes https://github.com/ome/ome-model/issues/156. Can re-add any of these if the build ends up failing.

Note that the only reference to `http://www.definiens.com` is also removed, as I don't think it makes sense to keep a broken link for something that's permanently gone. https://web.archive.org/web/20190927000502/https://www.definiens.com/ is I believe the last valid archive page. Happy to follow some other approach, but this is sort of the same problem as https://github.com/ome/bio-formats-documentation/pull/409.