### PR TITLE
Clarify the use of "Plane" elements in artifical example data

### DIFF
--- a/ome-tiff/data.rst
+++ b/ome-tiff/data.rst
@@ -112,6 +112,9 @@ section of the OME Data Model, derived from the public
 
 See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature 464(7289):721 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3108885/>`__.
 
+
+.. _sub-resolutions:
+
 Sub-resolutions
 ^^^^^^^^^^^^^^^
 

--- a/ome-tiff/data.rst
+++ b/ome-tiff/data.rst
@@ -162,8 +162,11 @@ Artificial datasets
 ^^^^^^^^^^^
 
 All datasets in the following table are single OME-TIFF files generated using
-Bio-Formats ``loci.formats.tools.MakeTestOmeTiff``. Each plane is labeled
-according to its dimensional position for easy testing.
+Bio-Formats ``loci.formats.tools.MakeTestOmeTiff``. Dimensional information
+is included in the pixel data for each plane, for easier testing of plane indexing
+and dimension order. Note that no OME-XML `Plane` elements are populated in these
+examples; see :ref:`modulo-datasets` and :ref:`sub-resolutions` for examples with
+`Plane` elements.
 
 .. list-table::
   :header-rows: 1


### PR DESCRIPTION
Fixes https://github.com/ome/ome-model/issues/73.

This is intended to clarify the current state of artificial example OME-TIFF data, in particular that there are no `Plane` elements for this set of examples but that the ZCT indexes are "burned in" to the images themselves.

I'm not particularly inclined to update the `MakeTestOmeTiff` example and regenerate these files (since there are other examples of how to use `Plane`), but can do if any strong feelings.